### PR TITLE
:memo: Add ceedling adapter to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Currently the following Test Adapters are available:
 * [Mocha Test Explorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-mocha-test-adapter)
 * [Jasmine Test Explorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-jasmine-test-adapter)
 
+### C
+
+* [Ceedling Test Explorer](https://marketplace.visualstudio.com/items?itemName=numaru.vscode-ceedling-test-adapter)
+
 ### C++
 
 * [Google Test Explorer](https://marketplace.visualstudio.com/items?itemName=OpenNingia.vscode-google-test-adapter)


### PR DESCRIPTION
Hello,

I wrote an adapter for a C test framework call Ceedling and I wants to add it to the available adapter list of the README.