### PR TITLE
Do not update skipped tests on reload

### DIFF
--- a/src/tree/testNode.ts
+++ b/src/tree/testNode.ts
@@ -30,8 +30,6 @@ export class TestNode implements TreeNode {
 			let currentState = oldNode.state.current;
 			if (info.skipped) {
 				currentState = 'skipped';
-			} else if (currentState === 'skipped') {
-				currentState = 'pending';
 			}
 
 			this._state = {


### PR DESCRIPTION
In the tree, the state of a skipped test from a test run should remain the
same on reload.
The 'skipped' state has two meanings; A skipped test from a reload and
a skipped test from a test run. If a test is "unskipped from reload", it should
get the retired version of its state before skipping.