### PR TITLE
Add Rust Test Adapter info to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Currently the following Test Adapters are available:
 
 * [Python Test Explorer](https://marketplace.visualstudio.com/items?itemName=LittleFoxTeam.vscode-python-test-adapter)
 
+### Rust
+
+* [Rust Test Explorer](https://marketplace.visualstudio.com/items?itemName=swellaby.vscode-rust-test-adapter)
+
 ### Live Share
 
 * The [Test Explorer Live Share](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer-liveshare) extension creates Test Adapters in


### PR DESCRIPTION
First let me say what an awesome extension this is! The Test Explorer is a great add to VS Code, and the way it was constructed makes it really straightforward to add new adapters. 

We've built a test adapter for [Rust](https://www.rust-lang.org/) and [have published it to the marketplace ](https://marketplace.visualstudio.com/items?itemName=swellaby.vscode-rust-test-adapter) 

This PR adds the corresponding info for the Rust Test Adapter to this project's Readme. 