### PR TITLE
add Bandit C++ to list of test adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Currently the following Test Adapters are available:
 
 * [Catch2 and Google Test Explorer](https://marketplace.visualstudio.com/items?itemName=matepek.vscode-catch2-test-adapter)
 * [CppUnitTestFramework Explorer](https://marketplace.visualstudio.com/items?itemName=drleq.vscode-cpputf-test-adapter)
+* [Bandit Test Explorer](https://marketplace.visualstudio.com/items?itemName=dampsoft.vscode-banditcpp-test-adapter)
 
 ### Haxe
 


### PR DESCRIPTION
First of all: Thanks for your Extension. It is really helpful and we use it a lot!
Because we're using a different C++ unit test framework than the existing adapters offer, we just released a test adapter extension for [Bandit C++](https://banditcpp.github.io/bandit/runningtests.html).

This PR adds a third C++ framework to readme.