### PR TITLE
Filter null from list of tests to run

### DIFF
--- a/src/testExplorer.ts
+++ b/src/testExplorer.ts
@@ -123,8 +123,11 @@ export class TestExplorer implements TestController, vscode.TreeDataProvider<Tre
 		this.lastTestRun = undefined;
 
 		if (nodes) {
+			// Remove all `null`s from the nodes array, in case there are any
+			// This can happen when this function is called via the command interface
+			const nodesWithoutNull = nodes.filter((x) => x !== null);
 
-			const nodesToRun = pick ? await pickNodes(nodes) : nodes;
+			const nodesToRun = pick ? await pickNodes(nodesWithoutNull) : nodesWithoutNull;
 			if (nodesToRun.length > 0) {
 				this.lastTestRun = [ nodesToRun[0].collection, getAdapterIds(nodesToRun) ];
 				nodesToRun[0].collection.adapter.run(getAdapterIds(nodesToRun));


### PR DESCRIPTION
This PR adds applies a filter for `null` to the list of nodes to run a test for.

### Rationale: 

Clicking on "Run test" in the tree view calls a command that has a variadic arguments list.
In the current version of VS Code (1.37.1), this results in a list of size `1`, containing exactly the test to execute.

![trigger](https://user-images.githubusercontent.com/4789818/64039718-9a23a300-cb5b-11e9-89ef-b732461819a4.png)

In the insiders version (tested with 1.38.0-insider), however, this results in a list of size `2`, where the second element is `null`. I tested this with two different test adapters (rust and catkin_tools), which behave the same:

![callback](https://user-images.githubusercontent.com/4789818/64039715-96901c00-cb5b-11e9-902b-18fb5e017ca2.jpg)

This results in an aborted test execution in `pickNodes()`, because `null` cannot be mapped through 
```js
nodes.map(node => node.info.label);
```

### Discussion

I could not find out if this is a bug in 1.38.0-insider or not. These changes are a workaround in case this will be the new behaviour.
