### PR TITLE
remove jext test adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Currently the following Test Adapters are available:
 * [Mocha Test Explorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-mocha-test-adapter)
 * [Jasmine Test Explorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-jasmine-test-adapter)
 * [Angular/Karma Test Explorer](https://marketplace.visualstudio.com/items?itemName=raagh.angular-karma-test-explorer)
-* [Jest Test Explorer](https://marketplace.visualstudio.com/items?itemName=rtbenfield.vscode-jest-test-adapter)
 * [AVA Test Explorer](https://marketplace.visualstudio.com/items?itemName=gwenio.vscode-ava-test-adapter)
 * [TestyTs Test Explorer](https://marketplace.visualstudio.com/items?itemName=Testy.vscode-testyts-test-adapter)
 


### PR DESCRIPTION
This was removed from the marketplace and github :( 
I should have a copy of the tree somewhere, not sure I feel like maintaining it though
And didn't check the licence either