### PR TITLE
feat: allow themes to customise editor error highlight colours

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,17 @@
     "*"
   ],
   "contributes": {
+    "colors": [
+      {
+        "id": "testExplorer.errorDecorationBackground",
+        "description": "Background color of the editor error decoration",
+        "defaults": {
+          "dark": "inputValidation.errorBackground",
+          "light": "inputValidation.errorBackground",
+          "highContrast": "inputValidation.errorBackground"
+        }
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Test Explorer",

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -20,9 +20,9 @@ export class Decorator {
 
 		this.stateDecorationTypes = new StateDecorationTypes(context, this.testExplorer.iconPaths);
 		this.errorDecorationType = vscode.window.createTextEditorDecorationType({
-			backgroundColor: 'rgba(255,0,0,0.3)',
+			backgroundColor: new vscode.ThemeColor('testExplorer.errorDecorationBackground'),
 			isWholeLine: true,
-			overviewRulerColor: 'rgba(255,0,0,0.3)',
+			overviewRulerColor: new vscode.ThemeColor('testExplorer.errorDecorationBackground'),
 		});
 		context.subscriptions.push(this.errorDecorationType);
 


### PR DESCRIPTION

This adds a new colour contribution point, `testExplorer.errorDecorationBackground` which theme authors (ie. me 😇) can use to customise the line highlight colour used when a test case fails. The colour inherits from the core colour `inputValidation.errorBackground` which immediatelly improves how the error decoration looks in built-in themes. It fits much more nicely now!