### PR TITLE
bugfix: skipped tests were run using autorun+retire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 2.18.1
+* bugfix: skipped tests were run using autorun+retire
+
 ### Version 2.18.0
 * Workaround for microsoft/vscode#94872, which broke some of the global menu items in the Test Explorer view
 * Allow test-explorer.reveal command argument to be the ID of a node

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Currently the following Test Adapters are available:
 
 ### C++
 
-* [Catch2 and Google Test Explorer](https://marketplace.visualstudio.com/items?itemName=matepek.vscode-catch2-test-adapter)
+* [C++ TestMate](https://marketplace.visualstudio.com/items?itemName=matepek.vscode-catch2-test-adapter)
 * [CMake Test Explorer](https://marketplace.visualstudio.com/items?itemName=fredericbonnet.cmake-test-adapter)
 * [CppUnitTestFramework Explorer](https://marketplace.visualstudio.com/items?itemName=drleq.vscode-cpputf-test-adapter)
 * [Bandit Test Explorer](https://marketplace.visualstudio.com/items?itemName=dampsoft.vscode-banditcpp-test-adapter)

--- a/src/tree/testCollection.ts
+++ b/src/tree/testCollection.ts
@@ -103,10 +103,13 @@ export class TestCollection {
 
 				if (!this._autorunNode) return;
 
+				const skippedFilter = (node:TreeNode) => node.info.type === 'suite' || node.info.skipped !== true;
+
 				if (this._autorunNode === this.rootSuite) {
-					this.adapter.run(getAdapterIds(nodes));
+					const nodesToRun = nodes.filter(skippedFilter);
+					this.adapter.run(getAdapterIds(nodesToRun));
 				} else {
-					const nodesToRun = intersect(this._autorunNode, nodes);
+					const nodesToRun = intersect(this._autorunNode, nodes).filter(skippedFilter);
 					if (nodesToRun.length > 0) {
 						this.adapter.run(getAdapterIds(nodesToRun));
 					}


### PR DESCRIPTION
Fixes #139 