### PR TITLE
Make the 'enable'/'disable' option for the autorun of tests context-sensitive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-test-explorer",
-  "version": "2.18.1",
+  "version": "2.19.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -393,12 +393,12 @@
         {
           "command": "test-explorer.enable-autorun",
           "group": "1_autorun@1",
-          "when": "view == test-explorer"
+          "when": "view == test-explorer && !autorunEnabled"
         },
         {
           "command": "test-explorer.disable-autorun",
           "group": "1_autorun@2",
-          "when": "view == test-explorer"
+          "when": "view == test-explorer && autorunEnabled"
         },
         {
           "command": "test-explorer.retire",

--- a/src/testExplorer.ts
+++ b/src/testExplorer.ts
@@ -254,6 +254,7 @@ export class TestExplorer implements TestController, vscode.TreeDataProvider<Tre
 				collection.setAutorun(collection.suite);
 			}
 		}
+		vscode.commands.executeCommand('setContext', 'autorunEnabled', true);
 	}
 
 	clearAutorun(node?: any): void {
@@ -264,6 +265,7 @@ export class TestExplorer implements TestController, vscode.TreeDataProvider<Tre
 				collection.setAutorun(undefined);
 			}
 		}
+		vscode.commands.executeCommand('setContext', 'autorunEnabled', false);
 	}
 
 	retireState(node?: any): void {


### PR DESCRIPTION
Having an 'Enable autorun' in the menu that doesn't do anything visibly when autorun is enabled, and a similar 'Disable autorun' that doesn't do anything when autoruns are already disabled is annoying.

Fix this by switching the menu item into the correct state depending on whether autorun is currently enabled or disabled.