### PR TITLE
Handle empty workspaceFolders case

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,8 @@ export function activate(context: vscode.ExtensionContext): ITestHub {
 	const testExplorer = new TestExplorer(context);
 	hub.registerTestController(testExplorer);
 
-	const workspaceUri = (vscode.workspace.workspaceFolders !== undefined) ? vscode.workspace.workspaceFolders[0].uri : undefined;
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+	const workspaceUri = (workspaceFolders !== undefined && workspaceFolders.length > 0) ? workspaceFolders[0].uri : undefined;
 	const configuration = vscode.workspace.getConfiguration('testExplorer', workspaceUri);
 	const expandLevels = configuration.get<number>('showExpandButton') || 0;
 	const showCollapseAll = configuration.get<boolean>('showCollapseButton');


### PR DESCRIPTION
This change properly handles the case where the `workspaceFolders` array of the VS Code API is empty.