### PR TITLE
#177: Dedupe child nodes when added during test run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<!--
+
+Please add your own contribution below inside the Master section
+
+## Master
+* bugfix: tests were sometimes duplicated when describes were found while running tests (e.g. describe.each)
+-->
+
 ### Version 2.19.3
 * show source on tree item double-click
 * show workspace folder and Test Adapter label when the tests fail to load

--- a/src/tree/testCollection.ts
+++ b/src/tree/testCollection.ts
@@ -187,6 +187,13 @@ export class TestCollection {
 		}
 	}
 
+	private addChildNodes(children: TreeNode[]) {
+		children.forEach(childNode => {
+			this.nodesById.set(childNode.info.id, childNode);
+			this.addChildNodes(childNode.children);
+		});
+	}
+
 	private onTestRunEvent(testRunEvent: TestRunStartedEvent | TestRunFinishedEvent | TestSuiteEvent | TestEvent): void {
 		if (this.rootSuite === undefined) return;
 
@@ -249,7 +256,7 @@ export class TestCollection {
 					runningSuite.children.push(suiteNode);
 					runningSuite.recalcStateNeeded = true;
 					this.nodesById.set(suiteId, suiteNode);
-
+					this.addChildNodes(suiteNode.children);
 				}
 
 				if (suiteNode) {
@@ -311,7 +318,7 @@ export class TestCollection {
 				runningSuite.children.push(testNode);
 				runningSuite.recalcStateNeeded = true;
 				this.nodesById.set(testId, testNode);
-
+				this.addChildNodes(testNode.children);
 			}
 
 			if (testNode) {


### PR DESCRIPTION
When test run event contains children, the children were already being added to the resulting `testSuiteNode`.  Now the children are also added to `nodesById` to avoid them being duplicated when events for them are sent.  This fixes #177.

### Before PR
![image](https://user-images.githubusercontent.com/9260413/103477935-60872b80-4d91-11eb-8949-7bf59ca42bdc.png)

### After PR
![image](https://user-images.githubusercontent.com/9260413/103477933-57965a00-4d91-11eb-8fe6-a58e619a12a7.png)

