### PR TITLE
Support "workspace trust" feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "test",
     "testing"
   ],
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "main": "out/main.js",
   "scripts": {
     "reinstall": "rimraf node_modules package-lock.json && npm install",


### PR DESCRIPTION
👋🏽 I've been working on a [different extension](https://github.com/github/vscode-codeql/) that uses this test explorer and we'd like to allow our extension to run in untrusted workspaces (see https://github.com/github/vscode-codeql/pull/861). To do this, its dependencies (i.e. the test explorer) also need to run in untrusted workspaces.

For extra context: VS Code recently introduced the concept where, if users have the workspace trust feature enabled, they can explicitly "trust" certain folders/workspaces.
- Overview of the concept: https://github.com/microsoft/vscode/issues/106488
- Guide for extension authors: https://github.com/microsoft/vscode/issues/120251#issuecomment-825832603

By default, any extension that doesn't support workspace trust, is disabled in untrusted workspaces. I've had a look at the feature contributions for this extension and it seems like it doesn't directly run code from the workspace. As such, it should be safe to use in untrusted workspaces too 🎉 Fixes #205.