### PR TITLE
Using natural sorting so numbers.

### DIFF
--- a/src/tree/sort.ts
+++ b/src/tree/sort.ts
@@ -26,7 +26,7 @@ export function getCompareFn(sortSetting: SortSetting | null | undefined): ((a: 
 }
 
 function compareLabel(a: TreeNode, b: TreeNode): number {
-	return a.info.label.localeCompare(b.info.label);
+	return a.info.label.localeCompare(b.info.label, undefined, { numeric: true });
 }
 
 function compareLocation(a: TreeNode, b: TreeNode): number {


### PR DESCRIPTION
This PR will enable the natural sort when sorting tests. Without this, the sorting of tests would be 

```
test_1
test_10
test_11
test_9
```

With the natural sorting, the tests are in correct order: 

```
test_1
test_9
test_10
test_11
```